### PR TITLE
Change pkg version to 0.1.1 to fix the missing data folder issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ required_packages = ["boto3>=1.10.44, < 2.0"]
 
 setuptools.setup(
     name="sagemaker_studio_sparkmagic_lib",
-    version="0.1",
+    version="0.1.1",
     author="Amazon Web Services",
     description="Python Command line tool to manage configuration of sparkmagic kernels on studio",
     long_description=long_description,


### PR DESCRIPTION
*Issue #, if available:*
No issue, pypi does not allow overriding previous version. We have to bounce the micro version for the a minor fix. 
*Description of changes:*
Bounce version to 0.1.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
