### PR TITLE
Provide instructions in README to override EMR endpoint in VPC endpoints 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ This is a CLI tool for generating configuration of SparkMagic, Kerberos required
 
 This CLI tool comes pre-installed on Studio SparkMagic Image. It can be used from any notebook created from that image. 
 
-* **Connecting to non-kerberos cluster**: In a notebook cell, execute following commands
+#### Connecting to non-kerberos cluster: 
+In a notebook cell, execute following commands
 
 ```
 %local
@@ -34,7 +35,9 @@ Please complete following steps to complete the connection
 1. Restart kernel to complete your setup. This is required so SparkMagic can pickup generated configuration
 ```
 
-* **Connecting to kerberos cluster**: Its very simialr to non-kerberos cluster, except you can pass 
+#### Connecting to kerberos cluster: 
+
+It's very similar to non-kerberos cluster, except you can pass 
 
 ```
 !sm-sparkmagic connect --cluster-id "j-xxxxxxxx" --user-name "ec2-user"
@@ -48,7 +51,8 @@ Please follow below steps to complete the setup:
 2. Restart kernel to complete your setup. This is required so SparkMagic can pickup generated configuration
 ```
 
-* **Connecting to EMR cluster in another account**: To setup configuration for EMR cluster in another account, run following command
+#### Connecting to EMR cluster in another account 
+To setup configuration for EMR cluster in another account, run following command
 
 ```
 %local
@@ -56,6 +60,26 @@ Please follow below steps to complete the setup:
 !sm-sparkmagic connect --cluster-id "j-xxxxx" --role-arn "arn:aws:iam::222222222222:role/role-on-emr-cluster-account"
 ```
 
+#### Connecting to EMR cluster in a private subnet over VPC Endpoints
+
+There is a bug in [botocore](https://github.com/boto/botocore/issues/2376) which requires the user to override the endpoint for EMR clients when using over [VPC Endpoints](https://docs.aws.amazon.com/emr/latest/ManagementGuide/interface-vpc-endpoint.html). As this library uses the default boto3 configuration, this may cause issues while connecting to clusters over VPC Endpoints. 
+
+As a workaround, run the following code snippet to override the default EMR endpoint in boto3
+
+```python
+%local
+import botocore
+import json
+import os
+
+with open(os.path.join(os.path.dirname(botocore.__file__), 'data', 'endpoints.json'), 'r+') as f:
+    data = json.load(f)
+    # Use [1] for aws-cn
+    data['partitions'][0]['services']['elasticmapreduce']['defaults']['sslCommonName'] = '{service}.{region}.{dnsSuffix}'
+    f.seek(0)
+    json.dump(data, f)
+    f.truncate()
+```
 
 ### FAQ
 * Can I connect to multiple clusters at same time?


### PR DESCRIPTION
There is a bug in botocore boto/botocore#2376 where the default EMR endpoints resolves to `us-west-2.elasticmapreduce.amazonaws.com`. The DNS names for these VPC endpoints do not match the URL configured and so you have to force via the endpoint_url option when you create the client.

This commit provides a temporary workaround for customers to patch the botocore endpoint configuration for usage with EMR VPC endpoints. As a proper fix, we should update the EMR clients in this library to specify endpoint_url while creating the EMR client

#### Testing Done

Tested in SageMaker Studio connected to a private subnet with EMR VPC endpoint. Run this snippet in the PySpark kernel, and then validated that I was able to call `emr.list_clusters()`