### PR TITLE
Fix Kerberos configuration for external KDC EMR's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+dist*
+.idea*
+*.egg-info*
+__pycache__
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.2
+* Fix "krb5.conf" generated file for external KDC cases
+* Add ChangeLog and Update README

--- a/README.md
+++ b/README.md
@@ -60,27 +60,6 @@ To setup configuration for EMR cluster in another account, run following command
 !sm-sparkmagic connect --cluster-id "j-xxxxx" --role-arn "arn:aws:iam::222222222222:role/role-on-emr-cluster-account"
 ```
 
-#### Connecting to EMR cluster in a private subnet over VPC Endpoints
-
-There is a bug in [botocore](https://github.com/boto/botocore/issues/2376) which requires the user to override the endpoint for EMR clients when using over [VPC Endpoints](https://docs.aws.amazon.com/emr/latest/ManagementGuide/interface-vpc-endpoint.html). As this library uses the default boto3 configuration, this may cause issues while connecting to clusters over VPC Endpoints. 
-
-As a workaround, run the following code snippet to override the default EMR endpoint in boto3
-
-```python
-%local
-import botocore
-import json
-import os
-
-with open(os.path.join(os.path.dirname(botocore.__file__), 'data', 'endpoints.json'), 'r+') as f:
-    data = json.load(f)
-    # Use [1] for aws-cn
-    data['partitions'][0]['services']['elasticmapreduce']['defaults']['sslCommonName'] = '{service}.{region}.{dnsSuffix}'
-    f.seek(0)
-    json.dump(data, f)
-    f.truncate()
-```
-
 ### FAQ
 * Can I connect to multiple clusters at same time?
   * You can only connect to one cluster at a time. Tool generates configuration needed to connect to one cluster. If you want to connect to different cluster, one has to re-execute the command providing different cell
@@ -131,6 +110,11 @@ sm.connect_to_emr_cluster(cluster_id= "j-xxx", user_name="ec2-user", krb_file_ov
      spark_magic_override_path="/tmp/config.json", restart_kernel=False)
 ```
 
+* To test on studio, create a tar ball and install on studio or your custom image accordingly
+
+```
+python setup.py sdist
+```
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/sagemaker_studio_sparkmagic_lib/emr.py
+++ b/sagemaker_studio_sparkmagic_lib/emr.py
@@ -5,6 +5,7 @@ import sys
 import boto3
 import botocore
 import logging
+from sagemaker_studio_sparkmagic_lib import utils
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -20,7 +21,9 @@ class EMRCluster:
     def __init__(self, cluster_id=None, role_arn=None, emr=None):
         if not emr:
             sess = self._get_boto3_session(role_arn)
-            emr = sess.client("emr")
+            emr = sess.client(
+                "emr", endpoint_url=utils.get_emr_endpoint_url(self._get_region())
+            )
         self._get_cluster(emr, cluster_id)
         self._get_instances(emr, cluster_id)
         self._get_security_conf(emr)
@@ -146,6 +149,52 @@ class EMRCluster:
 
         return master_instance_details["PrivateDnsName"]
 
+    def krb_hostname_override(self):
+        """
+        According to kerberos https://github.com/requests/requests-kerberos/blob/master/README.rst
+        "
+        If communicating with a host whose DNS name doesn't match its kerberos hostname (eg, behind a content switch or
+        load balancer), the hostname used for the Kerberos GSS exchange can be overridden by setting the hostname_override
+        "
+
+        Since we are communicating from studio host not registered in EMR one has to override hostname matching DNS/DHCP options
+        """
+        hostname = self.primary_node_private_dns_name()
+        search = utils.get_domain_search(self._get_region())
+        if search != utils.get_default_domain_search(self._get_region()):
+            names = hostname.split(".")
+            if len(names) > 1:
+                hostname = f"{names[0]}.{search}"
+
+        return hostname
+
+    def get_kinit_user_name(self, user_name):
+        """
+        Generates exact user name to be used for kinit. Depending on Kerberos configuration user may
+        have to use realm name to do kinit
+        """
+        if self.is_krb_cluster:
+            sec_krb_conf = self._sec_conf["AuthenticationConfiguration"][
+                "KerberosConfiguration"
+            ]
+            krb_provider = sec_krb_conf["Provider"]
+            if krb_provider == "ExternalKdc":
+                kdc_conf = sec_krb_conf["ExternalKdcConfiguration"]
+                ad_integ_conf = kdc_conf["AdIntegrationConfiguration"]
+                return f"{user_name}@{ad_integ_conf['AdRealm']}"
+
+        return user_name
+
+    def is_external_kdc(self):
+        if not self.is_krb_cluster:
+            return False
+        sec_krb_conf = self._sec_conf["AuthenticationConfiguration"][
+            "KerberosConfiguration"
+        ]
+        krb_provider = sec_krb_conf["Provider"]
+
+        return krb_provider == "ExternalKdc"
+
     def get_krb_conf(self):
         """
         Generate kerberos configuration parameters for a given EMR cluster.
@@ -164,18 +213,24 @@ class EMRCluster:
         # Kerberos server config on EMR cluster
         properties = {}
         emr_realm_name = self._cluster["KerberosAttributes"]["Realm"]
+        # DNS Search value is used for domain_realm mappings and other kerberos properties
+        # We have learned that using DNS Search is needed instead of AWS default DNS values for kerberos to work
+        search = utils.get_domain_search(self._get_region())
+
         emr_realm_attr = {
             "kdc": f"{self.primary_node_private_dns_name()}:88",
             "admin_server": f"{self.primary_node_private_dns_name()}:749",
-            "default_domain": f"{self._get_region()}.compute.internal",
+            "default_domain": f"{search}",
         }
 
         properties["realms"] = {emr_realm_name: emr_realm_attr}
         properties["libdefaults"] = {"default_realm": emr_realm_name}
+
+        # map emr realm to domain search value
         properties["domain_realm"] = {
-            f"{self._get_region()}.compute.internal": f"{emr_realm_name}",
+            search: f"{emr_realm_name}",
             # not the same key as above. There is a dot at the beginning of key
-            f".{self._get_region()}.compute.internal": f"{emr_realm_name}",
+            f".{search}": f"{emr_realm_name}",
         }
         sec_krb_conf = self._sec_conf["AuthenticationConfiguration"][
             "KerberosConfiguration"
@@ -185,7 +240,7 @@ class EMRCluster:
             kdc_conf = sec_krb_conf["ClusterDedicatedKdcConfiguration"]
             properties["libdefaults"][
                 "ticket_lifetime"
-            ] = f'{kdc_conf["TicketLifetimeInHours"]}h'
+            ] = f'{kdc_conf.get("TicketLifetimeInHours", "24")}h'
             if "CrossRealmTrustConfiguration" in kdc_conf:
                 cross_real_conf = kdc_conf["CrossRealmTrustConfiguration"]
                 cross_realm = cross_real_conf["Realm"]
@@ -201,11 +256,25 @@ class EMRCluster:
             kdc_conf = sec_krb_conf["ExternalKdcConfiguration"]
             properties["libdefaults"][
                 "ticket_lifetime"
-            ] = f'{kdc_conf["TicketLifetimeInHours"]}h'
-            ad_integ_conf = kdc_conf["AdIntegrationConfiguration"]
-            properties["realms"][ad_integ_conf["AdRealm"]] = {
+            ] = f'{kdc_conf.get("TicketLifetimeInHours", "24")}h'
+
+            # For external kdc configuration default realm-properties should point to external kdc server
+            emr_realm_attr = {
                 "kdc": kdc_conf["KdcServer"],
                 "admin_server": kdc_conf["AdminServer"],
+                "default_domain": f"{search}",
+            }
+
+            properties["realms"][emr_realm_name] = emr_realm_attr
+            ad_integ_conf = kdc_conf["AdIntegrationConfiguration"]
+            properties["realms"][ad_integ_conf["AdRealm"]] = {
+                # For external kdc configuration parameter AdServer is not documented in EMR public docs
+                # We found from some use cases that parameter AdServer Exists
+                # and it should be used as KDC Server
+                "kdc": ad_integ_conf.get("AdServer", ad_integ_conf["AdDomain"]),
+                "admin_server": ad_integ_conf.get(
+                    "AdServer", ad_integ_conf["AdDomain"]
+                ),
                 "default_domain": ad_integ_conf["AdDomain"],
             }
             ext_realm = ad_integ_conf["AdRealm"]

--- a/sagemaker_studio_sparkmagic_lib/sparkmagic.py
+++ b/sagemaker_studio_sparkmagic_lib/sparkmagic.py
@@ -70,7 +70,7 @@ def connect_to_emr_cluster(
             # user has not provided a user name as input, we use place holder to hint user to use actual user name
             krb_user_name = "$user"
         user_steps.append(
-            f"Open the image terminal and run 'kinit {krb_user_name}'(user_name: {krb_user_name}) to get kerberos ticket"
+            f"Open the image terminal and run 'kinit {cluster.get_kinit_user_name(krb_user_name)}' to get kerberos ticket"
         )
 
     # auto-restart kernel
@@ -129,7 +129,7 @@ def _write_spark_magic_conf(cluster, user_name, skip_krb, spark_magic_override_p
             "delegate": False,
             "force_preemptive": True,
             "principal": "",
-            "hostname_override": cluster.primary_node_private_dns_name(),
+            "hostname_override": cluster.krb_hostname_override(),
             "sanitize_mutual_error_response": True,
             "send_cbt": False,
         }

--- a/sagemaker_studio_sparkmagic_lib/tests/emr_test.py
+++ b/sagemaker_studio_sparkmagic_lib/tests/emr_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import boto3
 import pytest
 from botocore.stub import Stubber
@@ -6,18 +8,12 @@ from sagemaker_studio_sparkmagic_lib.emr import EMRCluster
 
 
 def test_get_cluster_happy_case_non_kerberos():
-    emr = boto3.client("emr")
+    emr = boto3.client("emr", region_name="us-west-2")
     with Stubber(emr) as emr_stub:
         describe_cluster_response = {
             "Cluster": {"Id": "j-3DD9ZR01DAU14", "Name": "Mycluster"}
         }
-        list_instances_response = {
-            "Instances": [
-                {
-                    "Id": "j-3DD9ZR01DAU14",
-                }
-            ]
-        }
+        list_instances_response = {"Instances": [{"Id": "j-3DD9ZR01DAU14",}]}
         emr_stub.add_response("describe_cluster", describe_cluster_response)
         emr_stub.add_response("list_instances", list_instances_response)
         emr_cluster = EMRCluster(cluster_id="j-3DD9ZR01DAU14", emr=emr)
@@ -29,7 +25,7 @@ def test_get_cluster_happy_case_non_kerberos():
 
 
 def test_get_cluster_happy_case_kerberos():
-    emr = boto3.client("emr")
+    emr = boto3.client("emr", region_name="us-west-2")
     with Stubber(emr) as emr_stub:
         describe_cluster_response = {
             "Cluster": {
@@ -38,13 +34,7 @@ def test_get_cluster_happy_case_kerberos():
                 "SecurityConfiguration": "kerb-security-config",
             }
         }
-        list_instances_response = {
-            "Instances": [
-                {
-                    "Id": "j-3DD9ZR01DAU14",
-                }
-            ]
-        }
+        list_instances_response = {"Instances": [{"Id": "j-3DD9ZR01DAU14",}]}
         describe_sec_conf_response = {
             "Name": "kerb-security-config",
             "SecurityConfiguration": "{}",
@@ -62,23 +52,19 @@ def test_get_cluster_happy_case_kerberos():
 
 
 def test_get_bad_cluster():
-    emr = boto3.client("emr")
+    emr = boto3.client("emr", region_name="us-west-2")
     with Stubber(emr) as emr_stub:
-        list_instances_response = {
-            "Instances": [
-                {
-                    "Id": "j-3DD9ZR01DAU14",
-                }
-            ]
-        }
+        list_instances_response = {"Instances": [{"Id": "j-3DD9ZR01DAU14",}]}
         emr_stub.add_client_error("describe_cluster", service_error_code=400)
         emr_stub.add_response("list_instances", list_instances_response)
         with pytest.raises(ValueError) as e:
             EMRCluster(cluster_id="j-3DD9ZR01DAU14", emr=emr)
 
 
-def test_cluster_dedicated_krb_cluster():
-    emr = boto3.client("emr")
+@patch("sagemaker_studio_sparkmagic_lib.utils.get_domain_search")
+def test_cluster_dedicated_krb_cluster(mock_utils):
+    mock_utils.return_value = "test.me"
+    emr = boto3.client("emr", region_name="us-west-2")
     with Stubber(emr) as emr_stub:
         describe_cluster_response = {
             "Cluster": {
@@ -127,20 +113,20 @@ def test_cluster_dedicated_krb_cluster():
                 "KTEST.COM": {
                     "kdc": "ip-172-31-1-113.us-west-2.compute.internal:88",
                     "admin_server": "ip-172-31-1-113.us-west-2.compute.internal:749",
-                    "default_domain": "us-west-2.compute.internal",
+                    "default_domain": "test.me",
                 }
             },
             "libdefaults": {"default_realm": "KTEST.COM", "ticket_lifetime": "24h"},
-            "domain_realm": {
-                "us-west-2.compute.internal": "KTEST.COM",
-                ".us-west-2.compute.internal": "KTEST.COM",
-            },
+            "domain_realm": {"test.me": "KTEST.COM", ".test.me": "KTEST.COM",},
         }
         assert emr_cluster.get_krb_conf() == krb_props
+        assert emr_cluster.get_kinit_user_name("ec2-user") == "ec2-user"
 
 
-def test_cross_realm_krb_cluster():
-    emr = boto3.client("emr")
+@patch("sagemaker_studio_sparkmagic_lib.utils.get_domain_search")
+def test_cross_realm_krb_cluster(mock_utils):
+    mock_utils.return_value = "test.me"
+    emr = boto3.client("emr", region_name="us-west-2")
     with Stubber(emr) as emr_stub:
         describe_cluster_response = {
             "Cluster": {
@@ -191,7 +177,7 @@ def test_cross_realm_krb_cluster():
                 "EC2.INTERNAL": {
                     "kdc": "ip-172-31-1-113.us-west-2.compute.internal:88",
                     "admin_server": "ip-172-31-1-113.us-west-2.compute.internal:749",
-                    "default_domain": "us-west-2.compute.internal",
+                    "default_domain": "test.me",
                 },
                 "KOLLOJUN.NET": {
                     "kdc": "kollojun.net",
@@ -201,10 +187,91 @@ def test_cross_realm_krb_cluster():
             },
             "libdefaults": {"default_realm": "EC2.INTERNAL", "ticket_lifetime": "24h"},
             "domain_realm": {
-                "us-west-2.compute.internal": "EC2.INTERNAL",
-                ".us-west-2.compute.internal": "EC2.INTERNAL",
+                "test.me": "EC2.INTERNAL",
+                ".test.me": "EC2.INTERNAL",
                 ".kollojun.net": "KOLLOJUN.NET",
                 "kollojun.net": "KOLLOJUN.NET",
             },
         }
         assert emr_cluster.get_krb_conf() == krb_props
+        assert emr_cluster.get_kinit_user_name("ec2-user") == "ec2-user"
+
+
+@patch("sagemaker_studio_sparkmagic_lib.utils.get_domain_search")
+def test_external_kdc_cluster(mock_utils):
+    mock_utils.return_value = "test.me"
+    emr = boto3.client("emr", region_name="us-west-2")
+    with Stubber(emr) as emr_stub:
+        describe_cluster_response = {
+            "Cluster": {
+                "Id": "j-3DD9ZR01DAU14",
+                "Name": "Mycluster",
+                "SecurityConfiguration": "kerb-security-config",
+                "KerberosAttributes": {
+                    "ADDomainJoinPassword": "********",
+                    "Realm": "MYKERBEROSREALM.COM",
+                    "ADDomainJoinUser": "********",
+                    "KdcAdminPassword": "********",
+                },
+                "MasterPublicDnsName": "ec2-34-222-47-14.us-west-2.compute.amazonaws.com",
+            }
+        }
+        list_instances_response = {
+            "Instances": [
+                {
+                    "Id": "j-3DD9ZR01DAU14",
+                    "Ec2InstanceId": "i-0736242069217a485",
+                    "PublicDnsName": "ec2-34-222-47-14.us-west-2.compute.amazonaws.com",
+                    "PublicIpAddress": "34.222.47.14",
+                    "PrivateDnsName": "ip-172-31-1-113.us-west-2.compute.internal",
+                    "PrivateIpAddress": "172.31.1.113",
+                }
+            ]
+        }
+        describe_sec_conf_response = {
+            "Name": "kerb-security-config",
+            "SecurityConfiguration": '{"AuthenticationConfiguration":{"KerberosConfiguration":'
+            '{"ExternalKdcConfiguration":{"KdcServerType":"Single","AdIntegrationConfiguration":'
+            '{"AdRealm":"MYADDOMAIN.COM","AdDomain":"myaddomain.com","AdServer":"myaddomain.com"},'
+            '"AdminServer":"ip-10-0-0-164.us-west-2.compute.internal",'
+            '"KdcServer":"ip-10-0-0-164.us-west-2.compute.internal"}'
+            ',"Provider":"ExternalKdc"}}}',
+        }
+        emr_stub.add_response("describe_cluster", describe_cluster_response)
+        emr_stub.add_response("list_instances", list_instances_response)
+        emr_stub.add_response(
+            "describe_security_configuration", describe_sec_conf_response
+        )
+        emr_cluster = EMRCluster(cluster_id="j-3DD9ZR01DAU14", emr=emr)
+        assert emr_cluster.is_krb_cluster
+        assert (
+            emr_cluster.primary_node_private_dns_name()
+            == "ip-172-31-1-113.us-west-2.compute.internal"
+        )
+        krb_props = {
+            "realms": {
+                "MYKERBEROSREALM.COM": {
+                    "kdc": "ip-10-0-0-164.us-west-2.compute.internal",
+                    "admin_server": "ip-10-0-0-164.us-west-2.compute.internal",
+                    "default_domain": "test.me",
+                },
+                "MYADDOMAIN.COM": {
+                    "kdc": "myaddomain.com",
+                    "admin_server": "myaddomain.com",
+                    "default_domain": "myaddomain.com",
+                },
+            },
+            "libdefaults": {
+                "default_realm": "MYKERBEROSREALM.COM",
+                "ticket_lifetime": "24h",
+            },
+            "domain_realm": {
+                "test.me": "MYKERBEROSREALM.COM",
+                ".test.me": "MYKERBEROSREALM.COM",
+                ".myaddomain.com": "MYADDOMAIN.COM",
+                "myaddomain.com": "MYADDOMAIN.COM",
+            },
+        }
+        assert emr_cluster.get_krb_conf() == krb_props
+        assert emr_cluster.get_kinit_user_name("ec2-user") == "ec2-user@MYADDOMAIN.COM"
+        assert emr_cluster.krb_hostname_override() == "ip-172-31-1-113.test.me"

--- a/sagemaker_studio_sparkmagic_lib/tests/utils_test.py
+++ b/sagemaker_studio_sparkmagic_lib/tests/utils_test.py
@@ -1,0 +1,52 @@
+from unittest.mock import mock_open, patch
+
+from sagemaker_studio_sparkmagic_lib import utils
+
+
+def test_get_domain_search_without_search_line():
+    with patch("builtins.open", mock_open(read_data="data")) as mock_file:
+        result = utils.get_domain_search("us-west-2")
+        mock_file.assert_called_with("/etc/resolv.conf", "r")
+        assert result == utils.get_default_domain_search("us-west-2")
+
+
+def test_get_domain_search_happy_case():
+    resolv_contents = (
+        "# comment\n"
+        "search eu-west-1.user.test\n"
+        "nameserver 10.0.0.145\n"
+        "nameserver 10.0.0.2\n"
+        "options timeout:2 attempts:5"
+    )
+
+    with patch("builtins.open", mock_open(read_data=resolv_contents)) as mock_file:
+        result = utils.get_domain_search("eu-west-1")
+        mock_file.assert_called_with("/etc/resolv.conf", "r")
+        assert result == "eu-west-1.user.test"
+
+
+@patch("builtins.open")
+def test_get_domain_search_resolv_does_not_exist(mock_open):
+    mock_open.side_effect = FileNotFoundError
+    result = utils.get_domain_search("eu-west-1")
+    mock_open.assert_called_with("/etc/resolv.conf", "r")
+    assert result == utils.get_default_domain_search("eu-west-1")
+
+
+def test_get_emr_endpoint_url():
+    assert (
+        utils.get_emr_endpoint_url("us-west-2")
+        == "https://elasticmapreduce.us-west-2.amazonaws.com"
+    )
+    assert (
+        utils.get_emr_endpoint_url("cn-north-1")
+        == "https://elasticmapreduce.cn-north-1.amazonaws.com.cn"
+    )
+    assert (
+        utils.get_emr_endpoint_url("eu-west-1")
+        == "https://elasticmapreduce.eu-west-1.amazonaws.com"
+    )
+    assert (
+        utils.get_emr_endpoint_url("us-gov-east-1")
+        == "https://elasticmapreduce.us-gov-east-1.amazonaws.com"
+    )

--- a/sagemaker_studio_sparkmagic_lib/utils.py
+++ b/sagemaker_studio_sparkmagic_lib/utils.py
@@ -1,0 +1,52 @@
+import logging
+import sys
+import boto3
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
+
+def get_default_domain_search(region):
+    return f"{region}.compute.internal"
+
+
+def get_emr_endpoint_url(region):
+    """
+    boto3 url for EMR is not constructed correctly in some regions See https://github.com/boto/botocore/issues/2376
+    @TODO: Deprecate after  https://github.com/boto/botocore/issues/2376 is fixed
+
+    This causes issues when customer use Private Link for EMR without internet connections
+
+    As per recommendation we construct EMR endpoints to match https://docs.aws.amazon.com/general/latest/gr/emr.html
+    """
+    sess = boto3.session.Session()
+    # tokenize endpoint url of format https://us-west-2.elasticmapreduce.amazonaws.com and ignore first two tokens
+    boto_url_tokens = sess.client("emr", region_name=region)._endpoint.host.split(".")
+    return f"https://elasticmapreduce.{region}.{'.'.join(boto_url_tokens[2:])}"
+
+
+def get_domain_search(region):
+    """
+    returns domain search by parsing /etc/resolv.conf
+    see https://man7.org/linux/man-pages/man5/resolv.conf.5.html
+    This value is used in kerberos config
+
+    NOTE: we should ideally read this information from studio metadata file as /etc/resolv.conf may not
+    be in all types of environments. Will be done as follow up
+    """
+    default_search = get_default_domain_search(region)
+    file = "/etc/resolv.conf"
+    try:
+        with open(file, "r") as resolvconf:
+            for line in resolvconf.readlines():
+                line = line.split("#", 1)[0]
+                line = line.rstrip()
+                if "search" in line:
+                    return line.split()[1]
+    except IOError:
+        logger.warning(
+            f"Unable to read {file}. Using default value for domain search name: {default_search}"
+        )
+
+    return default_search

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ required_packages = ["boto3>=1.10.44, < 2.0"]
 
 setuptools.setup(
     name="sagemaker_studio_sparkmagic_lib",
-    version="0.1.1",
+    version="0.1.2",
     author="Amazon Web Services",
     description="Python Command line tool to manage configuration of sparkmagic kernels on studio",
     long_description=long_description,


### PR DESCRIPTION
**Description**
EMR supports different kerberos configurations(https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-kerberos-options.html).
Our tooling generates kerberos configuration for all files. Customer is having trouble using generated
for External KDC configuration. This commit fixes them

1) TickerLifeTime is apparently optional parameter. we default it to 24h
if not present

2) KDC server for EMR realm is set as external KDC server and not
internal KDC server based on master node. Master node is stillused for
other configurations

3) DHCP setting derived from /etc/resolv.conf are used to map realm
values

4) Fix EMR URL issue found with private links and update README
accordingly

**Testing Done**

Build a tar file
```
python setup.py sdist
```

install on studio and tested with emr cluster

```
/opt/conda/bin/pip3 install --prefix=/opt/conda sagemaker_studio_sparkmagic_lib-0.1.2.tar.gz
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
