### PR TITLE
Paginate list_instances call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.3
+* Paginate list_instances call
+
 ## 0.1.2
 * Fix "krb5.conf" generated file for external KDC cases
 * Add ChangeLog and Update README

--- a/sagemaker_studio_sparkmagic_lib/emr.py
+++ b/sagemaker_studio_sparkmagic_lib/emr.py
@@ -74,7 +74,11 @@ class EMRCluster:
 
     def _get_instances(self, emr, cluster_id):
         try:
-            list_instances_response = emr.list_instances(ClusterId=cluster_id)
+            paginator = emr.get_paginator("list_instances")
+            page_iterator = paginator.paginate(ClusterId=cluster_id)
+            instances = []
+            for page in page_iterator:
+                instances.extend(page["Instances"])
         except botocore.exceptions.ClientError as ce:
             logger.debug(
                 f"Failed to list instances in  EMR cluster({cluster_id}) details. {ce.response}"
@@ -83,8 +87,8 @@ class EMRCluster:
                 f"Unable to list instances in EMR Cluster(Id: {cluster_id}) details using list-instances API."
                 f' Error: {ce.response["Error"]}'
             ) from None
-        logger.debug(f"List instances response: {list_instances_response}")
-        self._instances = list_instances_response["Instances"]
+        logger.debug(f"List instances response: {instances}")
+        self._instances = instances
 
     def _get_security_conf(self, emr):
         if "SecurityConfiguration" not in self._cluster:
@@ -286,3 +290,4 @@ class EMRCluster:
 
     def _get_region(self):
         return os.getenv("AWS_REGION", "us-west-2")
+

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ required_packages = ["boto3>=1.10.44, < 2.0"]
 
 setuptools.setup(
     name="sagemaker_studio_sparkmagic_lib",
-    version="0.1.2",
+    version="0.1.3",
     author="Amazon Web Services",
     description="Python Command line tool to manage configuration of sparkmagic kernels on studio",
     long_description=long_description,


### PR DESCRIPTION
**Description**

EMR connection will fail if master node is not retrieved in the non-paginated list_instances call.
This commits paginates the call, reformats the file using `black` and bounces PyPI version.

resolves #2 

**Testing Done**

Added unit test.

```
❯ python3 -m black . && python3 -m pytest -vrfpP .                                                                                                                                          ─╯
All done! ✨ 🍰 ✨
10 files left unchanged.
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.7.10, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /workplace/shahvar/Astra/src/LooseLeafSparkMagicImage/SMStudioSparkMagicLib
plugins: anyio-3.3.0
collected 12 items

sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_cluster_happy_case_non_kerberos PASSED                                                                                      [  8%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_cluster_happy_case_non_kerberos_with_pagination PASSED                                                                      [ 16%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_cluster_happy_case_kerberos PASSED                                                                                          [ 25%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_bad_cluster PASSED                                                                                                          [ 33%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_cluster_dedicated_krb_cluster PASSED                                                                                            [ 41%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_cross_realm_krb_cluster PASSED                                                                                                  [ 50%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_external_kdc_cluster PASSED                                                                                                     [ 58%]
sagemaker_studio_sparkmagic_lib/tests/kerberos_test.py::test_generated_krb_conf PASSED                                                                                                  [ 66%]
sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_domain_search_without_search_line PASSED                                                                                  [ 75%]
sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_domain_search_happy_case PASSED                                                                                           [ 83%]
sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_domain_search_resolv_does_not_exist PASSED                                                                                [ 91%]
sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_emr_endpoint_url PASSED                                                                                                   [100%]
```

Also verified by installing on Studio and trying to connect to a cluster with 100 instances.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
