### PR TITLE
Add next token marker to emr tests

### DIFF
--- a/sagemaker_studio_sparkmagic_lib/emr.py
+++ b/sagemaker_studio_sparkmagic_lib/emr.py
@@ -290,4 +290,3 @@ class EMRCluster:
 
     def _get_region(self):
         return os.getenv("AWS_REGION", "us-west-2")
-

--- a/sagemaker_studio_sparkmagic_lib/tests/emr_test.py
+++ b/sagemaker_studio_sparkmagic_lib/tests/emr_test.py
@@ -42,6 +42,7 @@ def test_get_cluster_happy_case_non_kerberos_with_pagination():
                     "Id": "j-7DD9ZR01DAU99",
                 }
             ],
+            "Marker": "nextToken",
         }
         list_instances_response_page_2 = {
             "Instances": [
@@ -331,4 +332,3 @@ def test_external_kdc_cluster(mock_utils):
         assert emr_cluster.get_krb_conf() == krb_props
         assert emr_cluster.get_kinit_user_name("ec2-user") == "ec2-user@MYADDOMAIN.COM"
         assert emr_cluster.krb_hostname_override() == "ip-172-31-1-113.test.me"
-


### PR DESCRIPTION
**Description**

Add next token marker to emr tests to allow paginator mock to retrieve
next token.

**Testing Done**

```
❯ python3 -m black . && python3 -m pytest -v .
All done! ✨ 🍰 ✨
10 files left unchanged.
======================================================== test session starts ========================================================
platform darwin -- Python 3.8.7, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /usr/local/opt/python@3.8/bin/python3.8
cachedir: .pytest_cache
rootdir: /Users/shahvar/sagemaker-studio-sparkmagic-lib
collected 12 items

sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_cluster_happy_case_non_kerberos PASSED                            [  8%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_cluster_happy_case_non_kerberos_with_pagination PASSED            [ 16%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_cluster_happy_case_kerberos PASSED                                [ 25%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_bad_cluster PASSED                                                [ 33%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_cluster_dedicated_krb_cluster PASSED                                  [ 41%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_cross_realm_krb_cluster PASSED                                        [ 50%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_external_kdc_cluster PASSED                                           [ 58%]
sagemaker_studio_sparkmagic_lib/tests/kerberos_test.py::test_generated_krb_conf PASSED                                        [ 66%]
sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_domain_search_without_search_line PASSED                        [ 75%]
sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_domain_search_happy_case PASSED                                 [ 83%]
sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_domain_search_resolv_does_not_exist PASSED                      [ 91%]
sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_emr_endpoint_url PASSED                                         [100%]

======================================================== 12 passed in 0.45s =========================================================
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
