### PR TITLE
Allow surfacing of primary node public dns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.4
+*  Allow surfacing of primary node public dns
+
 ## 0.1.3
 * Paginate list_instances call
 

--- a/sagemaker_studio_sparkmagic_lib/tests/emr_test.py
+++ b/sagemaker_studio_sparkmagic_lib/tests/emr_test.py
@@ -11,12 +11,21 @@ def test_get_cluster_happy_case_non_kerberos():
     emr = boto3.client("emr", region_name="us-west-2")
     with Stubber(emr) as emr_stub:
         describe_cluster_response = {
-            "Cluster": {"Id": "j-3DD9ZR01DAU14", "Name": "Mycluster"}
+            "Cluster": {
+                "Id": "j-3DD9ZR01DAU14",
+                "Name": "Mycluster",
+                "MasterPublicDnsName": "ec2-34-222-47-14.us-west-2.compute.amazonaws.com",
+            }
         }
         list_instances_response = {
             "Instances": [
                 {
                     "Id": "j-3DD9ZR01DAU14",
+                    "Ec2InstanceId": "i-0736242069217a485",
+                    "PublicDnsName": "ec2-34-222-47-14.us-west-2.compute.amazonaws.com",
+                    "PublicIpAddress": "34.222.47.14",
+                    "PrivateDnsName": "ip-172-31-1-113.us-west-2.compute.internal",
+                    "PrivateIpAddress": "172.31.1.113",
                 }
             ]
         }
@@ -34,12 +43,21 @@ def test_get_cluster_happy_case_non_kerberos_with_pagination():
     emr = boto3.client("emr", region_name="us-west-2")
     with Stubber(emr) as emr_stub:
         describe_cluster_response = {
-            "Cluster": {"Id": "j-3DD9ZR01DAU14", "Name": "Mycluster"}
+            "Cluster": {
+                "Id": "j-3DD9ZR01DAU14",
+                "Name": "Mycluster",
+                "MasterPublicDnsName": "ec2-34-222-47-14.us-west-2.compute.amazonaws.com",
+            }
         }
         list_instances_response_page_1 = {
             "Instances": [
                 {
-                    "Id": "j-7DD9ZR01DAU99",
+                    "Id": "j-3DD9ZR01DAU14",
+                    "Ec2InstanceId": "i-0736242069217a485",
+                    "PublicDnsName": "ec2-34-222-47-14.us-west-2.compute.amazonaws.com",
+                    "PublicIpAddress": "34.222.47.14",
+                    "PrivateDnsName": "ip-172-31-1-113.us-west-2.compute.internal",
+                    "PrivateIpAddress": "172.31.1.113",
                 }
             ],
             "Marker": "nextToken",
@@ -74,12 +92,18 @@ def test_get_cluster_happy_case_kerberos():
                 "Id": "j-3DD9ZR01DAU14",
                 "Name": "Mycluster",
                 "SecurityConfiguration": "kerb-security-config",
+                "MasterPublicDnsName": "ec2-34-222-47-14.us-west-2.compute.amazonaws.com",
             }
         }
         list_instances_response = {
             "Instances": [
                 {
                     "Id": "j-3DD9ZR01DAU14",
+                    "Ec2InstanceId": "i-0736242069217a485",
+                    "PublicDnsName": "ec2-34-222-47-14.us-west-2.compute.amazonaws.com",
+                    "PublicIpAddress": "34.222.47.14",
+                    "PrivateDnsName": "ip-172-31-1-113.us-west-2.compute.internal",
+                    "PrivateIpAddress": "172.31.1.113",
                 }
             ]
         }
@@ -162,6 +186,10 @@ def test_cluster_dedicated_krb_cluster(mock_utils):
             emr_cluster.primary_node_private_dns_name()
             == "ip-172-31-1-113.us-west-2.compute.internal"
         )
+        assert (
+            emr_cluster.primary_node_public_dns_name()
+            == "ec2-34-222-47-14.us-west-2.compute.amazonaws.com"
+        )
         krb_props = {
             "realms": {
                 "KTEST.COM": {
@@ -228,6 +256,10 @@ def test_cross_realm_krb_cluster(mock_utils):
         assert (
             emr_cluster.primary_node_private_dns_name()
             == "ip-172-31-1-113.us-west-2.compute.internal"
+        )
+        assert (
+            emr_cluster.primary_node_public_dns_name()
+            == "ec2-34-222-47-14.us-west-2.compute.amazonaws.com"
         )
         krb_props = {
             "realms": {
@@ -304,6 +336,10 @@ def test_external_kdc_cluster(mock_utils):
         assert (
             emr_cluster.primary_node_private_dns_name()
             == "ip-172-31-1-113.us-west-2.compute.internal"
+        )
+        assert (
+            emr_cluster.primary_node_public_dns_name()
+            == "ec2-34-222-47-14.us-west-2.compute.amazonaws.com"
         )
         krb_props = {
             "realms": {

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ required_packages = ["boto3>=1.10.44, < 2.0"]
 
 setuptools.setup(
     name="sagemaker_studio_sparkmagic_lib",
-    version="0.1.3",
+    version="0.1.4",
     author="Amazon Web Services",
     description="Python Command line tool to manage configuration of sparkmagic kernels on studio",
     long_description=long_description,


### PR DESCRIPTION
**Description**

Allow surfacing of primary node public dns

**Motivation**

Primary node public DNS is needed to connect to EMR cluster in public subnet.

**Testing Done**

- Updated unit tests

- `python3 -m black . && python3 -m pytest -vrfpP .`

```
============================================================================================================= short test summary info =============================================================================================================
PASSED sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_cluster_happy_case_non_kerberos
PASSED sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_cluster_happy_case_non_kerberos_with_pagination
PASSED sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_cluster_happy_case_kerberos
PASSED sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_bad_cluster
PASSED sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_cluster_dedicated_krb_cluster
PASSED sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_cross_realm_krb_cluster
PASSED sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_external_kdc_cluster
PASSED sagemaker_studio_sparkmagic_lib/tests/kerberos_test.py::test_generated_krb_conf
PASSED sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_domain_search_without_search_line
PASSED sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_domain_search_happy_case
PASSED sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_domain_search_resolv_does_not_exist
PASSED sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_emr_endpoint_url
=============================================================================================================== 12 passed in 0.63s ================================================================================================================```

**Backwards Compatibility Criteria (if any)**

N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
