### PR TITLE
Adding IPv6 support

### DIFF
--- a/sagemaker_studio_sparkmagic_lib/constants.py
+++ b/sagemaker_studio_sparkmagic_lib/constants.py
@@ -1,0 +1,3 @@
+from sagemaker_jupyterlab_extension_common.dual_stack_utils import is_dual_stack_enabled
+
+USE_DUALSTACK_ENDPOINT = is_dual_stack_enabled()

--- a/sagemaker_studio_sparkmagic_lib/emr.py
+++ b/sagemaker_studio_sparkmagic_lib/emr.py
@@ -6,6 +6,7 @@ import boto3
 import botocore
 import logging
 from sagemaker_studio_sparkmagic_lib import utils
+from sagemaker_studio_sparkmagic_lib.constants import USE_DUALSTACK_ENDPOINT
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -43,11 +44,19 @@ class EMRCluster:
             return boto3.session.Session()
         else:
             logger.info(f"Assuming role: {role_arn}")
-            sts_client = boto3.client("sts")
+            cfg = botocore.client.Config(
+                use_dualstack_endpoint=USE_DUALSTACK_ENDPOINT,
+            )
+            sts_client = boto3.client("sts", config=cfg)
             try:
                 assume_role_object = sts_client.assume_role(
                     RoleArn=role_arn, RoleSessionName="SageMakerStudioUser"
                 )
+            except (
+                botocore.exceptions.EndpointConnectionError,
+                botocore.exceptions.ConnectTimeoutError,
+            ) as e:
+                self.handle_endpoint_connection_errors(e)
             except botocore.exceptions.ClientError as ce:
                 logger.debug(
                     f"Failed to assume role: ({role_arn}) details. {ce.response}"
@@ -67,6 +76,11 @@ class EMRCluster:
     def _get_cluster(self, emr, cluster_id):
         try:
             describe_cluster_response = emr.describe_cluster(ClusterId=cluster_id)
+        except (
+            botocore.exceptions.EndpointConnectionError,
+            botocore.exceptions.ConnectTimeoutError,
+        ) as e:
+            self.handle_endpoint_connection_errors(e)
         except botocore.exceptions.ClientError as ce:
             logger.debug(
                 f"Failed to get EMR cluster({cluster_id}) details. {ce.response}"
@@ -85,6 +99,11 @@ class EMRCluster:
             instances = []
             for page in page_iterator:
                 instances.extend(page["Instances"])
+        except (
+            botocore.exceptions.EndpointConnectionError,
+            botocore.exceptions.ConnectTimeoutError,
+        ) as e:
+            self.handle_endpoint_connection_errors(e)
         except botocore.exceptions.ClientError as ce:
             logger.debug(
                 f"Failed to list instances in  EMR cluster({cluster_id}) details. {ce.response}"
@@ -133,6 +152,11 @@ class EMRCluster:
             describe_sec_conf_response = emr.describe_security_configuration(
                 Name=security_conf
             )
+        except (
+            botocore.exceptions.EndpointConnectionError,
+            botocore.exceptions.ConnectTimeoutError,
+        ) as e:
+            self.handle_endpoint_connection_errors(e)
         except botocore.exceptions.ClientError as ce:
             logger.debug(
                 f"Failed to get security configuration details({security_conf}) of EMR cluster({cluster_id})"
@@ -306,3 +330,10 @@ class EMRCluster:
 
     def _get_region(self):
         return os.getenv("AWS_REGION", "us-west-2")
+
+    def handle_endpoint_connection_errors(self, error):
+        """Handle endpoint connection errors consistently across client methods."""
+        logging.error("{} {}".format(str(error), traceback.format_exc()))
+        raise ConnectionError(
+            "Could not connect to EMR cluster. Please check your network settings or contact support for assistance."
+        )

--- a/sagemaker_studio_sparkmagic_lib/tests/utils_test.py
+++ b/sagemaker_studio_sparkmagic_lib/tests/utils_test.py
@@ -33,6 +33,7 @@ def test_get_domain_search_resolv_does_not_exist(mock_open):
     assert result == utils.get_default_domain_search("eu-west-1")
 
 
+@patch("sagemaker_studio_sparkmagic_lib.utils.USE_DUALSTACK_ENDPOINT", False)
 def test_get_emr_endpoint_url():
     assert (
         utils.get_emr_endpoint_url("us-west-2")
@@ -49,4 +50,24 @@ def test_get_emr_endpoint_url():
     assert (
         utils.get_emr_endpoint_url("us-gov-east-1")
         == "https://elasticmapreduce.us-gov-east-1.amazonaws.com"
+    )
+
+
+@patch("sagemaker_studio_sparkmagic_lib.utils.USE_DUALSTACK_ENDPOINT", True)
+def test_get_emr_endpoint_url_use_dualstack_endpoints():
+    assert (
+        utils.get_emr_endpoint_url("us-west-2")
+        == "https://elasticmapreduce.us-west-2.api.aws"
+    )
+    assert (
+        utils.get_emr_endpoint_url("cn-north-1")
+        == "https://elasticmapreduce.cn-north-1.api.amazonwebservices.com.cn"
+    )
+    assert (
+        utils.get_emr_endpoint_url("eu-west-1")
+        == "https://elasticmapreduce.eu-west-1.api.aws"
+    )
+    assert (
+        utils.get_emr_endpoint_url("us-gov-east-1")
+        == "https://elasticmapreduce.us-gov-east-1.api.aws"
     )

--- a/sagemaker_studio_sparkmagic_lib/utils.py
+++ b/sagemaker_studio_sparkmagic_lib/utils.py
@@ -1,6 +1,9 @@
 import logging
 import sys
 import boto3
+import botocore
+
+from sagemaker_studio_sparkmagic_lib.constants import USE_DUALSTACK_ENDPOINT
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -21,8 +24,13 @@ def get_emr_endpoint_url(region):
     As per recommendation we construct EMR endpoints to match https://docs.aws.amazon.com/general/latest/gr/emr.html
     """
     sess = boto3.session.Session()
+    cfg = botocore.client.Config(
+        use_dualstack_endpoint=USE_DUALSTACK_ENDPOINT,
+    )
     # tokenize endpoint url of format https://us-west-2.elasticmapreduce.amazonaws.com and ignore first two tokens
-    boto_url_tokens = sess.client("emr", region_name=region)._endpoint.host.split(".")
+    boto_url_tokens = sess.client(
+        "emr", region_name=region, config=cfg
+    )._endpoint.host.split(".")
     return f"https://elasticmapreduce.{region}.{'.'.join(boto_url_tokens[2:])}"
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,14 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-required_packages = ["boto3>=1.10.44, < 2.0"]
+required_packages = [
+    "boto3>=1.10.44, < 2.0", 
+    "sagemaker-jupyterlab-extension-common>=0.2.2, <1.0",
+]
 
 setuptools.setup(
     name="sagemaker_studio_sparkmagic_lib",
-    version="0.1.4",
+    version="0.2.0",
     author="Amazon Web Services",
     description="Python Command line tool to manage configuration of sparkmagic kernels on studio",
     long_description=long_description,


### PR DESCRIPTION
Adding IPv6 support

**Description**

- Added use_dualstack_endpoint flag to boto clients
- Added error handling for EndpointConnection and ConnectionTimeout errors thrown by boto when its unable to connect to a endpoint.

**Motivation**

Adding IPv6 support to EMR client 

**Testing Done**

- Updated unit tests

```
============================================================================================================= short test summary info =============================================================================================================
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_cluster_happy_case_non_kerberos PASSED                          [  7%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_private_cluster_happy_case_non_kerberos PASSED                  [ 14%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_cluster_happy_case_non_kerberos_with_pagination PASSED          [ 21%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_cluster_happy_case_kerberos PASSED                              [ 28%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_get_bad_cluster PASSED                                              [ 35%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_cluster_dedicated_krb_cluster PASSED                                [ 42%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_cross_realm_krb_cluster PASSED                                      [ 50%]
sagemaker_studio_sparkmagic_lib/tests/emr_test.py::test_external_kdc_cluster PASSED                                         [ 57%]
sagemaker_studio_sparkmagic_lib/tests/kerberos_test.py::test_generated_krb_conf PASSED                                      [ 64%]
sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_domain_search_without_search_line PASSED                      [ 71%]
sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_domain_search_happy_case PASSED                               [ 78%]
sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_domain_search_resolv_does_not_exist PASSED                    [ 85%]
sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_emr_endpoint_url PASSED                                       [ 92%]
sagemaker_studio_sparkmagic_lib/tests/utils_test.py::test_get_emr_endpoint_url_use_dualstack_endpoints PASSED               [100%] ================================================================================================================
```

**Backwards Compatibility Criteria (if any)**

Changes are backwards compatible with IPv4 only clients
